### PR TITLE
disconnected the store in App.js to avoid breaking withRouter

### DIFF
--- a/client/app.js
+++ b/client/app.js
@@ -1,21 +1,7 @@
 import React from 'react'
 import {Navbar, Sidebar} from './components'
-import {connect} from 'react-redux'
 
 import Routes from './routes'
-import {allProducts} from './store/products'
-
-function mapStateToProps(state) {
-  return {
-    products: state.products
-  }
-}
-
-function mapDispatchToProps(dispatch) {
-  return {
-    getProducts: () => dispatch(allProducts())
-  }
-}
 
 const App = () => {
   return (
@@ -27,4 +13,4 @@ const App = () => {
   )
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(App)
+export default App


### PR DESCRIPTION
fixes #58 

I need to disconect the store from app.js, this was breaking the withRouter in routes.js I don't think we will need the store in this element. but if needed we will need to rewire the router in order to work.